### PR TITLE
Don't allow benchmarked scripts to print on stdout and stderr when running them

### DIFF
--- a/benchmarks/asmjs-apps/harness.py
+++ b/benchmarks/asmjs-apps/harness.py
@@ -150,7 +150,7 @@ def BenchmarkJavaScript(options, args):
         for factor in range(0, 5):
             # Don't overwrite args!
             argv = [] + args
-            argv.extend(['run.js', '--', benchmark.name + '.js', str(factor)])
+            argv.extend(['-W', 'run.js', '--', benchmark.name + '.js', str(factor)])
             t = Exec(argv)
             t = t.strip()
             print(benchmark.name + '-workload' + str(factor) + ' - ' + t)

--- a/benchmarks/asmjs-apps/run.js
+++ b/benchmarks/asmjs-apps/run.js
@@ -19,7 +19,10 @@ var arguments = __ARGV__;
 function RunBenchmark(file)
 {
   var begin = Date.now();
+  var p = print, perr = printErr;
+  print = function(){}, perr = print;
   load(file);
+  print = p, printErr = perr;
   return Date.now() - begin;
 }
 

--- a/benchmarks/asmjs-ubench/harness.py
+++ b/benchmarks/asmjs-ubench/harness.py
@@ -59,7 +59,7 @@ def BenchmarkJavaScript(options, args):
     for benchmark in Benchmarks:
         # Don't overwrite args!
         argv = [] + args
-        argv.extend(['ubench.js', '--', benchmark + '.js', RunFactor])
+        argv.extend(['-W', 'ubench.js', '--', benchmark + '.js', RunFactor])
         t = Exec(argv)
         t = t.strip()
         print(benchmark + ' - ' + t)

--- a/benchmarks/asmjs-ubench/ubench.js
+++ b/benchmarks/asmjs-ubench/ubench.js
@@ -19,7 +19,10 @@ var arguments = __ARGV__;
 function RunBenchmark(file)
 {
   var begin = Date.now();
+  var p = print, perr = printErr;
+  print = function(){}, perr = print;
   load(file);
+  print = p, printErr = perr;
   return Date.now() - begin;
 }
 


### PR DESCRIPTION
Bonus point: -W shuts up the successful compilation messages.
