### PR TITLE
Don't provide -W flag

### DIFF
--- a/benchmarks/asmjs-apps/harness.py
+++ b/benchmarks/asmjs-apps/harness.py
@@ -150,7 +150,7 @@ def BenchmarkJavaScript(options, args):
         for factor in range(0, 5):
             # Don't overwrite args!
             argv = [] + args
-            argv.extend(['-W', 'run.js', '--', benchmark.name + '.js', str(factor)])
+            argv.extend(['run.js', '--', benchmark.name + '.js', str(factor)])
             t = Exec(argv)
             t = t.strip()
             print(benchmark.name + '-workload' + str(factor) + ' - ' + t)

--- a/benchmarks/asmjs-ubench/harness.py
+++ b/benchmarks/asmjs-ubench/harness.py
@@ -59,7 +59,7 @@ def BenchmarkJavaScript(options, args):
     for benchmark in Benchmarks:
         # Don't overwrite args!
         argv = [] + args
-        argv.extend(['-W', 'ubench.js', '--', benchmark + '.js', RunFactor])
+        argv.extend(['ubench.js', '--', benchmark + '.js', RunFactor])
         t = Exec(argv)
         t = t.strip()
         print(benchmark + ' - ' + t)


### PR DESCRIPTION
-W flag is already given by the AWFY harness for Spidermonkey, and it makes v8 failing (there is no chance it's the same flag). Moreover, it's not needed for v8 as it doesn't print the successful compilation warning.
