### PR TITLE
When an asmjs benchmark fails, continue to the next one.

### DIFF
--- a/benchmarks/asmjs-apps/harness.py
+++ b/benchmarks/asmjs-apps/harness.py
@@ -151,9 +151,12 @@ def BenchmarkJavaScript(options, args):
             # Don't overwrite args!
             argv = [] + args
             argv.extend(['run.js', '--', benchmark.name + '.js', str(factor)])
-            t = Exec(argv)
-            t = t.strip()
-            print(benchmark.name + '-workload' + str(factor) + ' - ' + t)
+            try:
+                t = Exec(argv)
+                t = t.strip()
+                print(benchmark.name + '-workload' + str(factor) + ' - ' + t)
+            except Exception as e:
+                print('Exception when running ' + benchmark.name + ': ' + str(e))
 
 def main(argv):
     parser = OptionParser()

--- a/benchmarks/asmjs-ubench/harness.py
+++ b/benchmarks/asmjs-ubench/harness.py
@@ -60,9 +60,12 @@ def BenchmarkJavaScript(options, args):
         # Don't overwrite args!
         argv = [] + args
         argv.extend(['ubench.js', '--', benchmark + '.js', RunFactor])
-        t = Exec(argv)
-        t = t.strip()
-        print(benchmark + ' - ' + t)
+        try:
+            t = Exec(argv)
+            t = t.strip()
+            print(benchmark + ' - ' + t)
+        except Exception as e:
+            print('Exception when running ' + benchmark.name + ': ' + str(e))
 
 def main(argv):
     parser = OptionParser()


### PR DESCRIPTION
For a few days now, the box2d benchmark is failing with an exception. Alon already submitted an issue to the v8 bug tracking system.

The issue is that it prevents the harness from running the other tests that work. This patch fixes that :)
