### PR TITLE
Add an incredibly simple micro benchmark for typed objects

### DIFF
--- a/benchmarks/misc/tests/assorted/LIST
+++ b/benchmarks/misc/tests/assorted/LIST
@@ -20,3 +20,5 @@ misc-bugs-847389-jpeg2000
 misc-f32-fft
 misc-f32-exp
 misc-f32-markov
+misc-typedobj-utf8array-typedobj.js
+misc-typedobj-utf8array-standard.js

--- a/benchmarks/misc/tests/assorted/misc-typedobj-utf8array-standard.js
+++ b/benchmarks/misc/tests/assorted/misc-typedobj-utf8array-standard.js
@@ -1,0 +1,19 @@
+// Paired with misc-typedobj-utf8array-standard.js
+
+function do_test() {
+  // Hand tweaked to get something around 1 seconds on my laptop.
+  var len = 192 * 100 * 1024;
+  var jsArray_in = new Array();
+  var jsArray_out = new Array();
+  for(var i = 0; i < len; i++) {
+    jsArray_in[i] = 1;
+  }
+  var sum = 0;
+  for(k = 0; k < 15; k++) {
+    for(i = 0; i < len; i++) {
+      jsArray_out[i] = jsArray_in[i];
+    }
+  }
+}
+do_test();
+

--- a/benchmarks/misc/tests/assorted/misc-typedobj-utf8array-typedobj.js
+++ b/benchmarks/misc/tests/assorted/misc-typedobj-utf8array-typedobj.js
@@ -1,0 +1,20 @@
+// Paired with misc-typedobj-utf8array-typedobj.js
+
+function do_test() {
+  // Hand tweaked to get something around 1 seconds on my laptop.
+  var len = 192 * 100 * 1024;
+  var BDType = TypedObject.uint8.array(len);
+  var bdArray_in = new BDType();
+  var bdArray_out = new BDType();
+  for(var i = 0; i < len; i++) {
+    bdArray_in[i] = 1;
+  }
+  var sum = 0;
+  for(var k = 0; k < 15; k++) {
+    for(i = 0; i < len; i++) {
+      bdArray_out[i] = bdArray_in[i];
+    }
+  }
+}
+do_test();
+


### PR DESCRIPTION
This benchmark just reads and writes from a uint8 array and compares the performance to a normal JS array. I expect to add more but I thought we'd start with something simple as a trial balloon.

Note: The API that we implement is not quite caught up with the spec, and the spec itself may yet change in some minor particulars. Therefore, I'll have to keep these tests synchronized, and we can expect that there may be a slight lag between when I push a change to the API and when the AWFY tests are updated. I guess that's ok? Alternatively, we could wait to add any tests, but I'd rather get perf feedback sooner than later.
