### PR TITLE
Microbenchmark for optimizing away intermediate objects when assigning to struct fields

### DIFF
--- a/benchmarks/misc/tests/assorted/misc-typedobj-write-struct-field-standard.js
+++ b/benchmarks/misc/tests/assorted/misc-typedobj-write-struct-field-standard.js
@@ -1,0 +1,37 @@
+// Paired with misc-typedobj-write-struct-field-typedobj.js
+
+function write(out, v0) {
+  out.pos[0] = v0[0];
+  out.pos[1] = v0[1];
+  out.pos[2] = v0[2];
+
+  out.nor[0] += v0[0];
+  out.nor[1] += v0[1];
+  out.nor[2] += v0[2];
+}
+
+function main() {
+  var start_time, end_time;
+
+  var p = { pos: [0, 0, 0],
+            nor: [0, 0, 0] };
+  var v = [1, 2, 3];
+  var len = 192 * 500 * 1024;
+
+  if (typeof TIME !== "undefined")
+    start_time = Date.now();
+
+  for (var i = 0; i < len; i++) {
+    v[0] = i+0.5;
+    v[1] = i+1.5;
+    v[2] = i+2.5;
+    write(p, v);
+  }
+
+  if (typeof TIME !== "undefined") {
+    end_time = Date.now();
+    print("Elapsed:", (end_time - start_time));
+  }
+}
+
+main();

--- a/benchmarks/misc/tests/assorted/misc-typedobj-write-struct-field-typedobj.js
+++ b/benchmarks/misc/tests/assorted/misc-typedobj-write-struct-field-typedobj.js
@@ -1,0 +1,43 @@
+// Paired with misc-typedobj-write-struct-field-standard.js
+
+var T = TypedObject;
+
+var ThreeVector = T.float64.array(3);
+var ThreeVectorArray = ThreeVector.array();
+var DisplaceResult = new T.StructType({pos: ThreeVector, nor: ThreeVector});
+var DisplaceResultArray = DisplaceResult.array();
+
+function write(out, v0) {
+  out.pos[0] = v0[0];
+  out.pos[1] = v0[1];
+  out.pos[2] = v0[2];
+
+  out.nor[0] += v0[0];
+  out.nor[1] += v0[1];
+  out.nor[2] += v0[2];
+}
+
+function main() {
+  var start_time, end_time;
+
+  var p = new DisplaceResult();
+  var v = [1, 2, 3];
+  var len = 192 * 500 * 1024;
+
+  if (typeof TIME !== "undefined")
+    start_time = Date.now();
+
+  for (var i = 0; i < len; i++) {
+    v[0] = i+0.5;
+    v[1] = i+1.5;
+    v[2] = i+2.5;
+    write(p, v);
+  }
+
+  if (typeof TIME !== "undefined") {
+    end_time = Date.now();
+    print("Elapsed:", (end_time - start_time));
+  }
+}
+
+main();


### PR DESCRIPTION
Bug 983977 -- Add two new microbenchmarks for optimizing away intermediate objects when assigning to struct fields
