### PR TITLE
Bug 1073033 - Add forEach benchmarks.

### DIFF
--- a/benchmarks/misc/tests/assorted/LIST
+++ b/benchmarks/misc/tests/assorted/LIST
@@ -26,3 +26,6 @@ misc-typedobj-write-struct-field-typedobj
 misc-typedobj-write-struct-field-standard
 misc-typedobj-simple-struct-typedobj
 misc-typedobj-simple-struct-standard
+misc-forEach-baseline
+misc-forEach-custom
+misc-forEach-library

--- a/benchmarks/misc/tests/assorted/misc-forEach-baseline.js
+++ b/benchmarks/misc/tests/assorted/misc-forEach-baseline.js
@@ -1,0 +1,34 @@
+var max_p = 5;
+
+function cnp_iter(n, p) {
+  p += 1;
+  var arr = (new Array(p)).fill(0);
+  arr[0] = 1;
+  for (var ni = 0; ni < n; ni++) {
+    var last = 0;
+    for (var pi = 0; pi < p; pi++) {
+      var tmp = last;
+      last = arr[pi];
+      arr[pi] = last + tmp;
+    }
+  }
+
+  return arr[p - 1];
+}
+
+function fact(low, max) {
+  var p = 1;
+  for (; low <= max; low++)
+    p *= low;
+  return p;
+}
+
+function cnp_ref(n, p) {
+  return Math.round( fact(n - p + 1, n) / fact(1, p) );
+}
+
+for (var n = max_p; n < 2000; n++) {
+  for (var p = 0; p < max_p; p++) {
+    assertEq(cnp_iter(n, p), cnp_ref(n, p));
+  }
+}

--- a/benchmarks/misc/tests/assorted/misc-forEach-custom.js
+++ b/benchmarks/misc/tests/assorted/misc-forEach-custom.js
@@ -1,0 +1,45 @@
+
+// This is a custom version of forEach which does not escape the lambda.
+Array.prototype.forEach = function(callbackfn) {
+    var O = this;
+    var len = O.length;
+    for (var k = 0; k < len; k++) {
+      callbackfn(O[k], k, O);
+    }
+
+    return undefined;
+};
+
+var max_p = 5;
+
+function cnp_iter(n, p) {
+  p += 1;
+  var arr = (new Array(p)).fill(0);
+  arr[0] = 1;
+  for (var ni = 0; ni < n; ni++) {
+    var last = 0;
+    arr.forEach(function (val, index, array) {
+      array[index] = last + val;
+      last = val;
+    });
+  }
+
+  return arr[p - 1];
+}
+
+function fact(low, max) {
+  var p = 1;
+  for (; low <= max; low++)
+    p *= low;
+  return p;
+}
+
+function cnp_ref(n, p) {
+  return Math.round( fact(n - p + 1, n) / fact(1, p) );
+}
+
+for (var n = max_p; n < 2000; n++) {
+  for (var p = 0; p < max_p; p++) {
+    assertEq(cnp_iter(n, p), cnp_ref(n, p));
+  }
+}

--- a/benchmarks/misc/tests/assorted/misc-forEach-library.js
+++ b/benchmarks/misc/tests/assorted/misc-forEach-library.js
@@ -1,0 +1,33 @@
+var max_p = 5;
+
+function cnp_iter(n, p) {
+  p += 1;
+  var arr = (new Array(p)).fill(0);
+  arr[0] = 1;
+  for (var ni = 0; ni < n; ni++) {
+    var last = 0;
+    arr.forEach(function (val, index, array) {
+      array[index] = last + val;
+      last = val;
+    });
+  }
+
+  return arr[p - 1];
+}
+
+function fact(low, max) {
+  var p = 1;
+  for (; low <= max; low++)
+    p *= low;
+  return p;
+}
+
+function cnp_ref(n, p) {
+  return Math.round( fact(n - p + 1, n) / fact(1, p) );
+}
+
+for (var n = max_p; n < 2000; n++) {
+  for (var p = 0; p < max_p; p++) {
+    assertEq(cnp_iter(n, p), cnp_ref(n, p));
+  }
+}


### PR DESCRIPTION
These micro benchmarks are comparing the performance of a simple for-loop written by hand against, a custom implementation of forEach which does not handle errors, and the implementation of forEach which is part of the self-hosted function.

The goal of these 3 benchmarks is to make sure that new primitive functions of JavaScript are as fast as hand-written code, and ensure that any custom polyfill would be as fast as the self-hosted version.

These benchmarks are running in about 30 to 70 ms each.
