### PR TITLE
Make it possible to print results in the console rather than sending them to a distant endpoint.

### DIFF
--- a/driver/dorequests.py
+++ b/driver/dorequests.py
@@ -16,6 +16,7 @@ import builders
 import puller
 import slaves
 import submitter
+from remotecontroller import RemoteController
 
 parser = OptionParser(usage="usage: %prog [options]")
 parser.add_option("-c", "--config", dest="config_name", type="string", default="awfy.config",
@@ -40,8 +41,8 @@ native = builders.NativeCompiler()
 
 # No updates. Report to server and wait 60 seconds, before moving on
 for slave in slaves.init():
-    submit = submitter.Submitter(slave)
-    revs = submit.RequestedRevs();
+    remotecontroller = RemoteController(slave)
+    revs = remotecontroller.RequestedRevs();
 
     for rev in revs:
         Engines, NumUpdated = builders.build(KnownEngines, rev = rev["cset"])
@@ -63,7 +64,7 @@ for slave in slaves.init():
         slave.prepare(Engines)
 
         # Inform AWFY of each mode we found.
-        submit = submitter.Submitter(slave)
+        submit = submitter.RemoteSubmitter(slave)
         submit.Start(rev["stamp"])
         for mode in modes:
             submit.AddEngine(mode.name, mode.cset)

--- a/driver/dostuff.py
+++ b/driver/dostuff.py
@@ -16,6 +16,7 @@ import builders
 import puller
 import slaves
 import submitter
+from remotecontroller import RemoteController
 
 parser = OptionParser(usage="usage: %prog [options]")
 parser.add_option("-f", "--force", dest="force", action="store_true", default=False,
@@ -24,6 +25,8 @@ parser.add_option("-n", "--no-update", dest="noupdate", action="store_true", def
                   help="Skip updating source repositories")
 parser.add_option("-c", "--config", dest="config_name", type="string", default="awfy.config",
                   help="Config file (default: awfy.config)")
+parser.add_option("-s", "--submitter", dest="submitter", type="string", default="remote",
+                  help="Submitter class ('remote' or 'print')")
 (options, args) = parser.parse_args()
 
 utils.config.init(options.config_name)
@@ -40,11 +43,19 @@ KnownEngines = [builders.MozillaInbound(),
                ]
 Engines, NumUpdated = builders.build(KnownEngines, not options.noupdate, options.force)
 
+Submitter = None
+if options.submitter == 'remote':
+    Submitter = submitter.RemoteSubmitter
+elif options.submitter == 'print':
+    Submitter = submitter.PrintSubmitter
+else:
+    raise Exception('unknown submitter!')
+
 # No updates. Report to server and wait 60 seconds, before moving on
 if NumUpdated == 0 and not options.force:
     for slave in slaves.init():
-        submit = submitter.Submitter(slave)
-        submit.Awake();
+        remotecontroller = RemoteController(slave)
+        remotecontroller.Awake();
     time.sleep(60)
     sys.exit(0)
 
@@ -68,14 +79,14 @@ for engine in Engines:
         mode = Mode(shell, args, env, m['mode'], engine.cset)
         modes.append(mode)
 
-# Set of slaves that run the builds. 
+# Set of slaves that run the builds.
 KnownSlaves = slaves.init()
 
 for slave in KnownSlaves:
     slave.prepare(Engines)
 
     # Inform AWFY of each mode we found.
-    submit = submitter.Submitter(slave)
+    submit = Submitter(slave)
     submit.Start()
     for mode in modes:
         submit.AddEngine(mode.name, mode.cset)

--- a/driver/remotecontroller.py
+++ b/driver/remotecontroller.py
@@ -1,0 +1,41 @@
+# vim: set ts=4 sw=4 tw=99 et:
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import urllib2
+
+import utils
+
+class RemoteController(object):
+    def __init__(self, slave):
+        self.machine = slave.machine
+        self.urls = utils.config.get('main', 'updateURL').split(",")
+        self.runIds = []
+        for i in range(len(self.urls)):
+            self.urls[i] = self.urls[i].strip()
+            self.runIds.append(0)
+
+    def RequestedRevs(self):
+        data = []
+        for i in range(len(self.urls)):
+            try:
+                url = self.urls[i]
+                url += '?requests=1'
+                url += '&MACHINE=' + str(self.machine)
+                url = urllib2.urlopen(url)
+                data += json.loads(url.read())
+            except urllib2.URLError:
+                pass
+        return data
+
+    def Awake(self):
+        for i in range(len(self.urls)):
+            try:
+                url = self.urls[i]
+                url += '?awake=yes'
+                url += '&MACHINE=' + str(self.machine)
+                urllib2.urlopen(url)
+            except urllib2.URLError:
+                pass
+

--- a/driver/slaves.py
+++ b/driver/slaves.py
@@ -67,14 +67,14 @@ class RemoteSlave(Slave):
             self.delayedCommand = str(fullcmd)
         else:
             utils.Run(fullcmd)
-        
+
     def pushRemote(self, file_loc, file_remote, follow = False):
         rsync_flags = "-aP"
         # if they asked us to follow symlinks, then add '-L' into the arguments.
         if follow:
             rsync_flags += "L"
         utils.Run(["rsync", rsync_flags, file_loc, self.HostName + ":" + file_remote])
-        
+
     def synchronize(self):
         if self.delayed:
             print("Waiting for: "+self.delayedCommand)
@@ -84,7 +84,7 @@ class RemoteSlave(Slave):
             self.delayed = None
             self.delayedCommand = None
 
-def init(): 
+def init():
     slaves = []
     slaveNames = utils.config.getDefault('main', 'slaves', None)
     if slaveNames:

--- a/driver/submitter.py
+++ b/driver/submitter.py
@@ -105,3 +105,11 @@ class PrintSubmitter(object):
         print "\n*******************************************\nSummary: "
         print self.msg
         self.msg = ''
+
+def getSubmitter(name):
+    if name == 'remote':
+        return RemoteSubmitter
+    elif name == 'print':
+        return PrintSubmitter
+    else:
+        raise Exception('unknown submitter!')

--- a/driver/submitter.py
+++ b/driver/submitter.py
@@ -4,42 +4,16 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 import re
-import utils
 import urllib
 import urllib2
 import json
 
-class Submitter:
+import utils
+from remotecontroller import RemoteController
+
+class RemoteSubmitter(RemoteController):
     def __init__(self, slave):
-        self.machine = slave.machine
-        self.urls = utils.config.get('main', 'updateURL').split(",")
-        self.runIds = []
-        for i in range(len(self.urls)):
-            self.urls[i] = self.urls[i].strip()
-            self.runIds.append(0)
-
-    def RequestedRevs(self):
-        data = []
-        for i in range(len(self.urls)):
-            try:
-                url = self.urls[i]
-                url += '?requests=1'
-                url += '&MACHINE=' + str(self.machine)
-                url = urllib2.urlopen(url)
-                data += json.loads(url.read())
-            except urllib2.URLError:
-                pass
-        return data
-
-    def Awake(self):
-        for i in range(len(self.urls)):
-            try:
-                url = self.urls[i]
-                url += '?awake=yes'
-                url += '&MACHINE=' + str(self.machine)
-                urllib2.urlopen(url)
-            except urllib2.URLError:
-                pass
+        super(RemoteSubmitter, self).__init__(slave)
 
     def Start(self, timestamp=None):
         for i in range(len(self.urls)):
@@ -101,3 +75,33 @@ class Submitter:
             url += '&status=' + str(status)
             url += '&runid=' + str(self.runIds[i])
             urllib2.urlopen(url)
+
+class PrintSubmitter(object):
+    def __init__(self, slave):
+        self.slave = slave
+        self.msg = ''
+
+    def log(self, msg):
+        self.msg += msg + '\n'
+        print msg
+
+    def Start(self, timestamp=None):
+        msg = "Starting benchmark"
+        if timestamp:
+            msg += " at timestamp" + str(timestamp)
+        self.log(msg)
+
+    def AddEngine(self, name, cset):
+        self.log("Added engine %s (changeset: %s)" % (name, cset))
+
+    def AddTests(self, tests, suite, suiteversion, mode):
+        for test in tests:
+            self.SubmitTest(test['name'], suite, suiteversion, mode, test['time'])
+
+    def SubmitTest(self, name, suite, suiteversion, mode, time):
+        self.log("%s (%s -- %s): %s" % (name, suiteversion, mode, str(time)))
+
+    def Finish(self, status):
+        print "\n*******************************************\nSummary: "
+        print self.msg
+        self.msg = ''


### PR DESCRIPTION
With this pull request, there is a new option: --submitter (aka -s), which can take two values: 'remote' or 'print'. Default is 'remote'. When the submitter is set to remote, results will be sent to the AWFY php service, as it's done currently. When the submitter is set to print, results will be printed once we're done, which allows to run AWFY locally more easily.