### PR TITLE
Fix a syntax bug in 'database/schema.sql'.

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -174,7 +174,7 @@ CREATE TABLE `awfy_breakdown` (
   `score` varchar(45) DEFAULT NULL,
   PRIMARY KEY (`id`),
   KEY `build_id` (`build_id`),
-  KEY `suite_test_id` (`suite_test_id`),
+  KEY `suite_test_id` (`suite_test_id`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=latin1 AUTO_INCREMENT=1 ;
 
 -- --------------------------------------------------------


### PR DESCRIPTION
The error appears when I was trying to initialize a new awfy db:

# mysql -uuser -ppass awfy < database/schema.sql

'''
ERROR 1064 (42000) at line 170: You have an error in your SQL syntax;
check the manual that corresponds to your MySQL server version for the
right syntax to use near
    ') ENGINE=MyISAM  DEFAULT CHARSET=latin1 AUTO_INCREMENT=1'
at line 9
'''