### PR TITLE
Add 'visible' column to 'awfy_suite' table.

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -82,6 +82,7 @@ CREATE TABLE `awfy_suite` (
   `description` varchar(45) CHARACTER SET utf8 COLLATE utf8_unicode_ci DEFAULT NULL,
   `better_direction` int(11) DEFAULT NULL,
   `sort_order` int(11) NOT NULL,
+  `visible` tinyint(1) NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `name_UNIQUE` (`name`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=latin1 AUTO_INCREMENT=9 ;


### PR DESCRIPTION
'server/update.py' wants to access 'visible' field in 'awfy_suite',
which is absent in 'database/schema.sql'.

    Computing master properties... Traceback (most recent call last):
      File "/home/awfy/awfy/server/update.py", line 359, in <module>
	main(sys.argv[1:])
      File "/home/awfy/awfy/server/update.py", line 350, in main
	cx = data.Context()
      File "/home/awfy/awfy/server/data.py", line 164, in __init__
	c.execute("SELECT id, name, description, better_direction, sort_order, visible FROM awfy_suite WHERE visible > 0")
      File "/home/awfy/awfy/server/awfy.py", line 44, in execute
	exe = self.cursor.execute(sql, data);
      File "/usr/lib/python2.7/dist-packages/MySQLdb/cursors.py", line 174, in execute
	self.errorhandler(self, exc, value)
      File "/usr/lib/python2.7/dist-packages/MySQLdb/connections.py", line 36, in defaulterrorhandler
	raise errorclass, errorvalue
    _mysql_exceptions.OperationalError: (1054, "Unknown column 'visible' in 'field list'")