### PR TITLE
Remove the v8-trubofan mode from testing.

### DIFF
--- a/driver/builders.py
+++ b/driver/builders.py
@@ -126,9 +126,6 @@ class V8(Engine):
         self.modes = [{
                         'mode': 'v8',
                         'args': None
-                      }, {
-                        'mode': 'v8-turbofan',
-                        'args': ['--turbo-filter=*', '--turbo-asm'] 
                       }]
 
     def build(self):


### PR DESCRIPTION
TurboFan is enabled by default now and is used selectively. The results for v8-turbofan are not relevant to released code and cause a lot of noise in the AWFY results.

What I am not sure about is how to remove the existing plot from the graphs?