### PR TITLE
Add correct v8-turbofan configuration.

### DIFF
--- a/driver/builders.py
+++ b/driver/builders.py
@@ -126,6 +126,9 @@ class V8(Engine):
         self.modes = [{
                         'mode': 'v8',
                         'args': None
+                      }, {
+                        'mode': 'v8-turbofan',
+                        'args': ['--turbo']
                       }]
 
     def build(self):


### PR DESCRIPTION
This is the configuration that we intend to ship at some point. The
--turbo flag is a meta flag that enables everything required to run
TurboFan in a sane way.