### PR TITLE
Wait for killall to finish.

### DIFF
--- a/slave/runners.py
+++ b/slave/runners.py
@@ -45,7 +45,11 @@ class Runner(object):
 class LinuxRunner(Runner):
     def killall(self, name):
         print "killall", name
-        subprocess.Popen(["killall", name])
+        process = subprocess.Popen(["killall", name])
+        # Wait for killall to finish
+        while process.poll() is None:
+            time.sleep(0.5)
+
 
     def killAllInstances(self):
         print "killallinstances"
@@ -60,7 +64,11 @@ class LinuxRunner(Runner):
 
 class OSXRunner(Runner):
     def killall(self, name):
-        subprocess.Popen(["killall", name])
+        print "killall", name
+        process = subprocess.Popen(["killall", name])
+        # Wait for killall to finish
+        while process.poll() is None:
+            time.sleep(0.5)
 
     def killAllInstances(self):
         if not os.path.exists(self.info["osx_mount_point"]):


### PR DESCRIPTION
Wait for killall to finish, else it ends up killing other instances created right after killall().

Since `killall()` doesn't wait for killall command to finish, it ends up killing the same processes spawned in near-future. See [this comment](https://github.com/dhananjay92/arewefastyet/issues/1#issuecomment-143049199) for some context. 

**Example:** In [ServoExecutor](https://github.com/dhananjay92/arewefastyet/commit/01f6a9#diff-975a8528dda6ea0a1090e7df97de1177R91), first we call [`killall()`](https://github.com/dhananjay92/arewefastyet/commit/01f6a9#diff-975a8528dda6ea0a1090e7df97de1177R100) and then [`runner.start()`](https://github.com/dhananjay92/arewefastyet/commit/01f6a9#diff-975a8528dda6ea0a1090e7df97de1177R106) is called. But that process gives -15 as error code. See [full output](https://gist.github.com/dhananjay92/39db7327922d1bfdda0d). It is because of this *race condition*. 