### PR TITLE
Update asm.js SIMD tests to the latest SIMD.js spec.

### DIFF
--- a/benchmarks/asmjs-ubench/fbirds-native.js
+++ b/benchmarks/asmjs-ubench/fbirds-native.js
@@ -65,6 +65,7 @@ function moduleCode(global, imp, buffer) {
 
     var i4 = global.SIMD.Int32x4;
     var f4 = global.SIMD.Float32x4;
+    var b4 = global.SIMD.Bool32x4;
     var i4add = i4.add;
     var i4and = i4.and;
     var f4select = f4.select;
@@ -75,6 +76,7 @@ function moduleCode(global, imp, buffer) {
     var f4splat = f4.splat;
     var f4load = f4.load;
     var f4store = f4.store;
+    var b4any = b4.anyTrue;
 
     const zerox4 = f4(0.0,0.0,0.0,0.0);
 
@@ -102,7 +104,7 @@ function moduleCode(global, imp, buffer) {
         var accelx4 = f4(0.0,0.0,0.0,0.0);
         var a = 0;
         var posDeltax4 = f4(0.0,0.0,0.0,0.0);
-        var cmpx4 = i4(0,0,0,0);
+        var cmpx4 = b4(0,0,0,0);
         var newVelTruex4 = f4(0.0,0.0,0.0,0.0);
 
         steps = getAccelDataSteps | 0;
@@ -129,7 +131,7 @@ function moduleCode(global, imp, buffer) {
                 newVelx4 = f4add(newVelx4, f4mul(accelx4, subTimeDeltax4));
                 cmpx4 = f4greaterThan(newPosx4, maxPosx4);
 
-                if (cmpx4.signMask) {
+                if (b4any(cmpx4)) {
                     // Work around unimplemented 'neg' operation, using 0 - x.
                     newVelTruex4 = f4sub(zerox4, newVelx4);
                     newVelx4 = f4select(cmpx4, newVelTruex4, newVelx4);

--- a/benchmarks/asmjs-ubench/mandelbrot-native.js
+++ b/benchmarks/asmjs-ubench/mandelbrot-native.js
@@ -35,6 +35,7 @@ function moduleCode(global, ffi, buffer) {
   var i4 = global.SIMD.Int32x4;
   var f4 = global.SIMD.Float32x4;
   var i4ext = i4.extractLane;
+  var i4sel = i4.select;
   var i4add = i4.add;
   var i4and = i4.and;
   var i4check = i4.check;
@@ -44,7 +45,9 @@ function moduleCode(global, ffi, buffer) {
   var f4lessThanOrEqual = f4.lessThanOrEqual;
   var f4splat = f4.splat;
   var imul = global.Math.imul;
-  const one4 = i4(1,1,1,1), two4 = f4(2,2,2,2), four4 = f4(4,4,4,4);
+  var b4 = global.SIMD.Bool32x4;
+  var b4any = b4.anyTrue;
+  const zero4 = i4(0,0,0,0), one4 = i4(1,1,1,1), two4 = f4(2,2,2,2), four4 = f4(4,4,4,4);
 
   const mk0 = 0x007fffff;
 
@@ -89,7 +92,7 @@ function moduleCode(global, ffi, buffer) {
     var z_re24 = f4(0,0,0,0), z_im24 = f4(0,0,0,0);
     var new_re4 = f4(0,0,0,0), new_im4 = f4(0,0,0,0);
     var i = 0;
-    var mi4 = i4(0,0,0,0);
+    var mb4 = b4(0,0,0,0);
 
     c_re4 = f4splat(xf);
     c_im4 = f4(yf, toF(yd + yf), toF(yd + toF(yd + yf)), toF(yd + toF(yd + toF(yd + yf))));
@@ -101,16 +104,16 @@ function moduleCode(global, ffi, buffer) {
       z_re24 = f4mul(z_re4, z_re4);
       z_im24 = f4mul(z_im4, z_im4);
 
-      mi4 = f4lessThanOrEqual(f4add(z_re24, z_im24), four4);
+      mb4 = f4lessThanOrEqual(f4add(z_re24, z_im24), four4);
       // If all 4 values are greater than 4.0, there's no reason to continue.
-      if ((mi4.signMask | 0) == 0x00)
+      if (!b4any(mb4))
         break;
 
       new_re4 = f4sub(z_re24, z_im24);
       new_im4 = f4mul(f4mul(two4, z_re4), z_im4);
       z_re4   = f4add(c_re4, new_re4);
       z_im4   = f4add(c_im4, new_im4);
-      count4  = i4add(count4, i4and(mi4, one4));
+      count4  = i4add(count4, i4sel(mb4, one4, zero4));
     }
     return i4check(count4);
   }


### PR DESCRIPTION
Firefox nightly is now (Bug 1160971) following the current SIMD.js spec which
includes boolean SIMD types, and the SIMD.Float32x4.lessThanOrEqual function is
returning a Bool32x4 instead of an Int32x4.

Update the two native SIMD tests to expect this return type.