### PR TITLE
Add a user agent to requests made to Treeherder's API

### DIFF
--- a/slave/download.py
+++ b/slave/download.py
@@ -162,8 +162,7 @@ class MozillaRevisionFinder(RevisionFinder):
 
     def _build_id(self, id):
         url = "https://treeherder.mozilla.org/api/project/"+self.repo+"/jobs/?count=2000&result_set_id="+str(id)+"&return_type=list"
-        response = urllib2.urlopen(url)
-        data = json.loads(response.read())
+        data = utils.fetch_json(url)
         builds = [i for i in data["results"] if i[1] == "buildbot"] # Builds
         builds = [i for i in builds if i[25] == "B" or i[25] == "Bo"] # Builds
         builds = [i for i in builds if i[13] == self.treeherder_platform()] # platform
@@ -172,16 +171,14 @@ class MozillaRevisionFinder(RevisionFinder):
         assert len(builds) == 1
 
         url = "https://treeherder.mozilla.org/api/project/mozilla-inbound/job-log-url/?job_id="+str(builds[0][10])
-        response = urllib2.urlopen(url)
-        data = json.loads(response.read())
+        data = utils.fetch_json(url)
         return data[0]["url"].split("/")[-2]
 
     def urlForRevision(self, cset):
         # here we use a detour using treeherder to find the build_id,
         # corresponding to a revision.
         url = "https://treeherder.mozilla.org/api/project/"+self.repo+"/resultset/?full=false&revision="+cset
-        response = urllib2.urlopen(url)
-        data = json.loads(response.read())
+        data = utils.fetch_json(url)
 
         # No corresponding build found given revision
         if len(data["results"]) != 1:

--- a/slave/utils.py
+++ b/slave/utils.py
@@ -9,7 +9,9 @@ import commands
 import subprocess
 import signal
 import ConfigParser
+import json
 import urllib
+import urllib2
 import tarfile
 import zipfile
 import stat
@@ -188,6 +190,16 @@ def unzip(directory, name):
 def chmodx(file):
     st = os.stat(file)
     os.chmod(file, st.st_mode | stat.S_IEXEC)
+
+def fetch_json(url):
+    # TODO: Replace urllib2 with requests.
+    headers = {
+        'Accept': 'application/json',
+        'User-Agent': 'arewefastyet',
+    }
+    request = urllib2.Request(url, headers=headers)
+    response = urllib2.urlopen(request)
+    return json.load(response)
 
 def getOrDownload(directory, prefix, revision, file, output):
     rev_file = directory + "/" + prefix + "-revision"

--- a/treeherder/submission.py
+++ b/treeherder/submission.py
@@ -17,6 +17,10 @@ except:
 	print "run 'sudo pip install treeherder-client' to install the needed libraries"
 	exit()
 
+DEFAULT_REQUEST_HEADERS = {
+    'Accept': 'application/json',
+    'User-Agent': 'arewefastyet',
+}
 RESULTSET_FRAGMENT = 'api/project/{repository}/resultset/?revision={revision}'
 JOB_FRAGMENT = '/#/jobs?repo={repository}&revision={revision}'
 BUILD_STATES = ['running', 'completed']
@@ -114,7 +118,7 @@ class Submission(object):
 
         logger.info('Getting revision hash from: {}'.format(lookup_url))
 
-        response = requests.get(lookup_url)
+        response = requests.get(lookup_url, headers=DEFAULT_REQUEST_HEADERS)
         response.raise_for_status()
 
         if not response.json():

--- a/treeherder/submission.py
+++ b/treeherder/submission.py
@@ -22,7 +22,7 @@ JOB_FRAGMENT = '/#/jobs?repo={repository}&revision={revision}'
 BUILD_STATES = ['running', 'completed']
 
 logging.basicConfig(format='%(asctime)s %(levelname)s | %(message)s', datefmt='%H:%M:%S')
-logger = logging.getLogger('mozmill-ci')
+logger = logging.getLogger('arewefastyet')
 logger.setLevel(logging.INFO)
 
 class Submission(object):


### PR DESCRIPTION
In bug 1230222 we're encouraging consumers of Treeherder's API to set user agent:
https://bugzilla.mozilla.org/show_bug.cgi?id=1230222

Ideally the two definitions of the user agent in this PR would be combined, however the current repo structure (lack of modules), sys.path manipulation and mixture of requests and urllib2, means it would involve a bit of refactoring, so this small bit of duplication seems fine for now.