### PR TITLE
SmallPage.h has been renamed SmallRun.h in r197955

### DIFF
--- a/slave/build.py
+++ b/slave/build.py
@@ -176,7 +176,7 @@ class WebkitBuilder(Builder):
             Run(["sed","-i.bac","s/GCC_TREAT_WARNINGS_AS_ERRORS = YES;/GCC_TREAT_WARNINGS_AS_ERRORS=NO;/","Source/bmalloc/Configurations/Base.xcconfig"])
             Run(["sed","-i.bac","s/GCC_TREAT_WARNINGS_AS_ERRORS = YES;/GCC_TREAT_WARNINGS_AS_ERRORS=NO;/","Source/WTF/Configurations/Base.xcconfig"])
             Run(["sed","-i.bac","s/std::numeric_limits<unsigned char>::max()/255/","Source/bmalloc/bmalloc/SmallLine.h"])
-            Run(["sed","-i.bac","s/std::numeric_limits<unsigned char>::max()/255/","Source/bmalloc/bmalloc/SmallPage.h"])
+            Run(["sed","-i.bac","s/std::numeric_limits<unsigned char>::max()/255/","Source/bmalloc/bmalloc/SmallRun.h"])
             Run(["patch","Source/JavaScriptCore/jsc.cpp", patch])
 
             # Hack 2: This check fails currently. Disable checking to still have a build.


### PR DESCRIPTION
SmallPage.h has been renamed SmallRun.h in http://trac.webkit.org/changeset/197955