### PR TITLE
Add map iterator to misc benchmark.

### DIFF
--- a/benchmarks/misc/tests/assorted/LIST
+++ b/benchmarks/misc/tests/assorted/LIST
@@ -39,3 +39,4 @@ misc-bugs-1090583-dart2js-tracer
 misc-basic-hoist-bounds-check
 misc-apply-array
 misc-apply-array-headroom
+misc-map-iterator

--- a/benchmarks/misc/tests/assorted/misc-map-iterator.js
+++ b/benchmarks/misc/tests/assorted/misc-map-iterator.js
@@ -1,0 +1,57 @@
+function assertEq(result, expected) {
+  if (result !== expected)
+    throw "Assertion: Expected " + expected + ", got " + result;
+}
+
+var loops = 10000;
+var entries = 100;
+
+var map = new Map();
+for (var i = 0; i < entries; i++)
+    map.set(i * 2, i * 3);
+
+function test_keys(m) {
+  for (var i = loops; i--;) {
+    var j = 0;
+    for (var k of m.keys()) {
+      assertEq(k, j * 2);
+      j++;
+    }
+  }
+}
+test_keys(map);
+
+function test_values(m) {
+  for (var i = loops; i--;) {
+    var j = 0;
+    for (var v of m.values()) {
+      assertEq(v, j * 3);
+      j++;
+    }
+  }
+}
+test_values(map);
+
+function test_entries(m) {
+  for (var i = loops; i--;) {
+    var j = 0;
+    for (var e of m.entries()) {
+      assertEq(e[0], j * 2);
+      assertEq(e[1], j * 3);
+      j++;
+    }
+  }
+}
+test_entries(map);
+
+function test_iterator(m) {
+  for (var i = loops; i--;) {
+    var j = 0;
+    for (var e of m) {
+      assertEq(e[0], j * 2);
+      assertEq(e[1], j * 3);
+      j++;
+    }
+  }
+}
+test_iterator(map);


### PR DESCRIPTION
Related to https://bugzilla.mozilla.org/show_bug.cgi?id=1248289

There I'm going to inline `_GetNextMapEntryForIterator` intrinsic, that is used in `%MapIteratorPrototype%.next`.
The inlined `_GetNextMapEntryForIterator` supports only boxed array for `mapIterationResultPair` (the temporary array to receive key-value pair from native function), and I expect some performance regression when unboxed array is enabled, and it's somehow used as `mapIterationResultPair` array (created in `MapIteratorObject::createResultPair`), as inlined code will be no more used for that case.

Locally, the inlining patch improves the score of this test from 252.0ms to 89.2ms.  So once this inlining become inapplicable, the score will be regressed to similar score as before.

To track it, I'd like to add this test.
