### PR TITLE
Add branch pruning config

### DIFF
--- a/slave/configs.py
+++ b/slave/configs.py
@@ -86,7 +86,15 @@ class FlowAA(Default):
             self.args_.append("--ion-aa=flow-sensitive");
         else:
             self.omit_ = True
-            
+
+class BranchPruning(Default):
+    def __init__(self, engine, shell):
+        super(BranchPruning, self).__init__(engine, shell)
+        if engine == "firefox":
+            self.env_["JIT_OPTION_disablePgo"] = 'false'
+        else:
+            self.omit_ = True
+
 class NonWritableJitcode(Default):
     def __init__(self, engine, shell):
         super(NonWritableJitcode, self).__init__(engine, shell)
@@ -138,4 +146,6 @@ def getConfig(name, info):
         return E10S(info["engine_type"], info["shell"])
     if name == "flowaa":
         return FlowAA(info["engine_type"], info["shell"])
+    if name == "branchpruning":
+        return BranchPruning(info["engine_type"], info["shell"])
     raise Exception("Unknown config")

--- a/slave/execute.py
+++ b/slave/execute.py
@@ -52,6 +52,7 @@ if options.mode_rules is None:
         "firefox,testbedregalloc:testbed",
         "firefox,nonwritablejitcode:nonwritablejitcode",
         "firefox,flowaa:flowaa",
+        "firefox,branchpruning:branchpruning",
         "firefox,e10s:e10s",
         "firefox,noe10s:noe10s",
         "chrome,default:v8",


### PR DESCRIPTION
This enabled Branch Pruning to make sure we can compare and tune our heuristics before landing.

Note, as opposed to flowAA, I wanted to enable it on dromaeo as well as the shell, so I am using the environment variable instead of the command line option.

cc @h4writer