### PR TITLE
[six-speed] Use Date.now() instead of new Date().

### DIFF
--- a/benchmarks/six-speed/test.js
+++ b/benchmarks/six-speed/test.js
@@ -2,11 +2,11 @@
 function assertEqual() {}
 function test(fn) {
     var its = iterations;
-    var start = new Date();
+    var start = Date.now();
     for (var i = 0; i < its; i++) {
         fn();
     }
-    timing = new Date() - start;
+    timing = Date.now() - start;
 }
 
 var tests = [


### PR DESCRIPTION
Using new Date() in the subtraction adds the time required to convert a
Date object to a Number to the measurement, which is not necessarily
what you want to measure, especially with micro benchmarks like these.