### PR TITLE
Use a temporary user directory for Chromium

### DIFF
--- a/slave/executors.py
+++ b/slave/executors.py
@@ -48,7 +48,7 @@ class BrowserExecutor(object):
         env = os.environ.copy()
         env.update(config.env())
         env.update(self.engineInfo["env"])
-        args = [benchmark.url] + config.args() + self.engineInfo["args"]
+        args = config.args() + self.engineInfo["args"] + [benchmark.url]
 
         self.execute(benchmark, env, args, config.profile())
 
@@ -167,8 +167,17 @@ class ChromeExecutor(BrowserExecutor):
         # reset the result
         self.resetResults()
 
+        # enforce an empty user data directory to clear caches and previous
+        # settings
+        runner.rm("profile/")
+        runner.mkdir("profile/")
+
+        effective_args = ["--disable-setuid-sandbox"] + \
+                         ["--user-data-dir=profile"] + \
+                         args
+
         # start browser
-        process = runner.start(binary, ["--disable-setuid-sandbox"] + args, env)
+        process = runner.start(binary, effective_args, env)
 
         # wait for results
         self.waitForResults(benchmark.timeout)


### PR DESCRIPTION
By default, Chromium uses a user data directory (think: profile directory for Chromium) that's outside our reach. I think that using a temporary directory and removing it between runs should lower the risk of incorrect browser cache hits. Here's a patch that implements that.

Also, just for sanity, the URL is appended after all other arguments in the BrowserExecutor. This removes the suspicion that args after the URL are ignored.